### PR TITLE
prevent cp clobbering into /usr/bin

### DIFF
--- a/razer_control_gui/install.sh
+++ b/razer_control_gui/install.sh
@@ -17,7 +17,7 @@ echo "Creating directories, copying files, and setting up services..."
 mkdir -p ~/.local/share/razercontrol
 sudo /bin/bash << EOF
 mkdir -p /usr/share/razercontrol
-cp target/release/razer-cli /usr/bin/
+cp -n target/release/razer-cli /usr/bin/
 cp target/release/daemon /usr/share/razercontrol/
 cp data/devices/laptops.json /usr/share/razercontrol/
 cp data/udev/99-hidraw-permissions.rules /etc/udev/rules.d/

--- a/razer_control_gui/install.sh
+++ b/razer_control_gui/install.sh
@@ -13,34 +13,68 @@ fi
 echo "Stopping razerdaemon service..."
 systemctl --user stop razerdaemon.service
 
-echo "Creating directories, copying files, and setting up services..."
-mkdir -p ~/.local/share/razercontrol
-sudo /bin/bash << EOF
-mkdir -p /usr/share/razercontrol
-cp -n target/release/razer-cli /usr/bin/
-cp target/release/daemon /usr/share/razercontrol/
-cp data/devices/laptops.json /usr/share/razercontrol/
-cp data/udev/99-hidraw-permissions.rules /etc/udev/rules.d/
-cp razerdaemon.service /usr/lib/systemd/user/
+if [[ -z "$@" ]];then
+    echo "usage: |install|uninstall|"
+    exit -1
+fi
+
+uninstall() {
+    sudo /bin/bash <<EOF
+rm -rf /usr/share/razercontrol
+rm -f /usr/bin/razer-cli
+rm -f /etc/udev/rules.d/99-hidraw-permissions.rules
+rm -f /usr/lib/systemd/user/razerdaemon.service
 udevadm control --reload-rules
 EOF
 
-# Check if the previous commands were successful
-if [ $? -ne 0 ]; then
-    echo "An error occurred while setting up, exiting."
-    exit 1
-fi
+}
+install() {
+    echo "Creating directories, copying files, and setting up services..."
+    mkdir -p ~/.local/share/razercontrol
+    sudo /bin/bash <<EOF
+mkdir -p /usr/share/razercontrol
+cp -n target/release/razer-cli /usr/bin/
+cp -n target/release/daemon /usr/share/razercontrol/
+cp -n data/devices/laptops.json /usr/share/razercontrol/
+cp -n data/udev/99-hidraw-permissions.rules /etc/udev/rules.d/
+cp -n razerdaemon.service /usr/lib/systemd/user/
+udevadm control --reload-rules
+EOF
 
-echo "Enabling razerdaemon service..."
-systemctl --user enable razerdaemon.service
+    # Check if the previous commands were successful
+    if [ $? -ne 0 ]; then
+        echo "An error occurred while setting up, exiting."
+        exit 1
+    fi
 
-echo "Starting razerdaemon service..."
-systemctl --user start razerdaemon.service
+    echo "Enabling razerdaemon service..."
+    systemctl --user enable razerdaemon.service
 
-# Check if the service started successfully
-if [ $? -ne 0 ]; then
-    echo "Failed to start razerdaemon service, exiting."
-    exit 1
-fi
+    echo "Starting razerdaemon service..."
+    systemctl --user start razerdaemon.service
 
-echo "Install complete!"
+    # Check if the service started successfully
+    if [ $? -ne 0 ]; then
+        echo "Failed to start razerdaemon service, exiting."
+        exit 1
+    fi
+
+    echo "Install complete!"
+
+    return $?
+}
+
+case "$@" in
+    "install")
+        install
+        ;;
+    "uninstall")
+        uninstall
+        ;;
+    *)
+        echo "unknown arg $@"
+        exit -1
+        ;;
+esac
+
+exit $?


### PR DESCRIPTION
Currently, this script blindly runs cp into /usr/bin. It shouldn't do that. If someone already had a program named razer-cli pointing to something like python-exec2c, then it breaks every call to every program pointing to python-exec2c on the system because what it ends up doing is replacing python-exec2c. Personally, I'm against utilities like this needing to be installed anywhere near /usr/bin and /usr/share. There's no reason to mess with system files. It can only ever break things. I figure this pr would start a conversation...