### PR TITLE
Add CPU boost for Blade 15 2022

### DIFF
--- a/razer_control_gui/data/devices/laptops.json
+++ b/razer_control_gui/data/devices/laptops.json
@@ -186,7 +186,7 @@
         "name": "Blade early 2022 15 advanced",
         "vid": "1532",
         "pid": "028A",
-        "features": [],
+        "features": ["boost"],
         "fan": [3500, 5000]
     },
     {


### PR DESCRIPTION
Boost mode is available in stock software for that laptop.

Model id verification:
```
$ lsusb | grep '1532:'
Bus 001 Device 004: ID 1532:028a Razer USA, Ltd Razer Blade
```
Rebuild and re-install package after that boost setting can be applied: 
```
$ razer-cli write power ac 4 3 2
RES: SetPowerMode { result: true }
RES: GetPwrLevel { pwr: 4 }
Current power setting: Custom
RES: GetCPUBoost { cpu: 3 }
Current CPU setting: Boost
RES: GetGPUBoost { gpu: 2 }
Current GPU setting: High
```
```
$ razer-cli read power ac
RES: GetPwrLevel { pwr: 4 }
Current power setting: Custom
RES: GetCPUBoost { cpu: 3 }
Current CPU setting: Boost
RES: GetGPUBoost { gpu: 2 }
Current GPU setting: High
``` 