### PR TITLE
check if install.sh was run with sudo

### DIFF
--- a/razer_control_gui/install.sh
+++ b/razer_control_gui/install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ "$EUID" -eq 0 ]
+  then echo "Please do not run as root"
+  exit
+fi
+
 if [[ -z "$@" ]];then
     echo "usage: |install|uninstall|"
     exit -1


### PR DESCRIPTION
This should save some people from a frequently made mistake. If there is an actual reason for somebody to run as root they can always just remove it from the script.