### PR TITLE
OpenRC: add missing dbus dependency

### DIFF
--- a/razer_control_gui/data/services/openrc/razercontrol
+++ b/razer_control_gui/data/services/openrc/razercontrol
@@ -6,7 +6,7 @@ pidfile="${XDG_RUNTIME_DIR}/${RC_SVCNAME}.pid"
 output="/var/log/razercontrol.log"
 
 depend() {
-    need localmount udev
+    need localmount udev dbus
 }
 
 start() {


### PR DESCRIPTION
Forgot to add dbus as a dependency for the OpenRC service resulting in the daemon starting before dbus and thus crashing.