### PR TITLE
Bugfixes

### DIFF
--- a/razer_control_gui/src/comms.rs
+++ b/razer_control_gui/src/comms.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 
 /// Razer laptop control socket path
-pub const SOCKET_PATH: &'static str = "/tmp/razercontrol-socket";
+pub const SOCKET_PATH: &str = "/tmp/razercontrol-socket";
 
 #[derive(Serialize, Deserialize, Debug)]
 /// Represents data sent TO the daemon

--- a/razer_control_gui/src/config.rs
+++ b/razer_control_gui/src/config.rs
@@ -54,25 +54,29 @@ impl Configuration {
 
     pub fn write_to_file(&mut self) -> io::Result<()> {
         let j: String = serde_json::to_string_pretty(&self)?;
-        File::create(env::var("HOME").unwrap() + SETTINGS_FILE)?.write_all(j.as_bytes())?;
+        File::create(get_home_directory() + SETTINGS_FILE)?.write_all(j.as_bytes())?;
         Ok(())
     }
 
     pub fn read_from_config() -> io::Result<Configuration> {
-        let str = fs::read_to_string(env::var("HOME").unwrap() + SETTINGS_FILE)?;
+        let str = fs::read_to_string(get_home_directory() + SETTINGS_FILE)?;
         let res: Configuration = serde_json::from_str(str.as_str())?;
         Ok(res)
     }
 
     pub fn write_effects_save(json: serde_json::Value) -> io::Result<()> {
         let j: String = serde_json::to_string_pretty(&json)?;
-        File::create(env::var("HOME").unwrap() + EFFECTS_FILE)?.write_all(j.as_bytes())?;
+        File::create(get_home_directory() + EFFECTS_FILE)?.write_all(j.as_bytes())?;
         Ok(())
     }
 
     pub fn read_effects_file() -> io::Result<serde_json::Value> {
-        let str = fs::read_to_string(env::var("HOME").unwrap() + EFFECTS_FILE)?;
+        let str = fs::read_to_string(get_home_directory() + EFFECTS_FILE)?;
         let res: serde_json::Value = serde_json::from_str(str.as_str())?;
         Ok(res)
     }
+}
+
+fn get_home_directory() -> String {
+    env::var("HOME").expect("The \"HOME\" environment variable must be set to a valid directory")
 }

--- a/razer_control_gui/src/daemon.rs
+++ b/razer_control_gui/src/daemon.rs
@@ -38,11 +38,13 @@ lazy_static! {
 
 // Main function for daemon
 fn main() {
-    std::panic::set_hook(Box::new(|_info| {
+    let default_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
         println!("Something went wrong! Removing the socket path");
         if std::fs::metadata(comms::SOCKET_PATH).is_ok() {
             std::fs::remove_file(comms::SOCKET_PATH).unwrap();
         }
+        default_panic_hook(info);
     }));
 
     if let Ok(mut d) = DEV_MANAGER.lock() {


### PR DESCRIPTION
The custom panic handler was not printing useful information during panics, now it calls the original handler after performing cleanup.

Also there is better crash info for https://github.com/Razer-Linux/razer-laptop-control-no-dkms/issues/63.