### PR TITLE
flake: add new build dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697009197,
-        "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
+        "lastModified": 1725194671,
+        "narHash": "sha256-tLGCFEFTB5TaOKkpfw3iYT9dnk4awTP/q4w+ROpMfuw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01441e14af5e29c9d27ace398e6dd0b293e25a54",
+        "rev": "b833ff01a0d694b910daca6e2ff4a3f26dee478c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,24 +6,31 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = inputs @ {
-    self,
-    nixpkgs,
-    flake-utils,
-  }:
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
     flake-utils.lib.eachDefaultSystem (
-      system: let
+      system:
+      let
         pkgs = nixpkgs.legacyPackages.${system};
         name = "razer-laptop-control";
-      in {
+      in
+      {
         formatter = pkgs.nixfmt-rfc-style;
 
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = name;
           version = "0.2.0";
 
-          nativeBuildInputs = with pkgs; [pkg-config];
-          buildInputs = with pkgs; [dbus.dev hidapi systemd];
+          nativeBuildInputs = with pkgs; [ pkg-config ];
+          buildInputs = with pkgs; [
+            dbus.dev
+            hidapi
+            systemd
+          ];
 
           src = ./razer_control_gui;
 
@@ -45,15 +52,18 @@
       }
     )
     // {
-      nixosModules.default = {
-        config,
-        lib,
-        pkgs,
-        ...
-      }:
-        with lib; let
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        with lib;
+        let
           cfg = config.services.razer-laptop-control;
-        in {
+        in
+        {
           options.services.razer-laptop-control = {
             enable = mkEnableOption "Enables razer-laptop-control";
             package = mkOption {
@@ -64,8 +74,8 @@
 
           config = mkIf cfg.enable {
             services.upower.enable = true;
-            environment.systemPackages = [cfg.package];
-            services.udev.packages = [cfg.package];
+            environment.systemPackages = [ cfg.package ];
+            services.udev.packages = [ cfg.package ];
 
             systemd.user.services."razerdaemon" = {
               description = "Razer laptop control daemon";
@@ -74,7 +84,7 @@
                 ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p %h/.local/share/razercontrol";
                 ExecStart = "${cfg.package}/libexec/daemon";
               };
-              wantedBy = ["default.target"];
+              wantedBy = [ "default.target" ];
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,8 @@
         pkgs = nixpkgs.legacyPackages.${system};
         name = "razer-laptop-control";
       in {
+        formatter = pkgs.nixfmt-rfc-style;
+
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = name;
           version = "0.2.0";

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,9 @@
             dbus.dev
             hidapi
             systemd
+            glib
+            pango
+            gtk3
           ];
 
           src = ./razer_control_gui;


### PR DESCRIPTION
**Summary:**
- Set the formatter for the flake to `nixfmt-rfc-style`.
- Fixed #74 by adding the required build dependencies.
- Added a new `.desktop` entry for the `razer-settings` GUI.