### PR TITLE
chore: lints and crate style

### DIFF
--- a/razer_control_gui/src/comms.rs
+++ b/razer_control_gui/src/comms.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::{UnixListener, UnixStream};
 
 /// Razer laptop control socket path
@@ -8,42 +9,84 @@ pub const SOCKET_PATH: &str = "/tmp/razercontrol-socket";
 #[derive(Serialize, Deserialize, Debug)]
 /// Represents data sent TO the daemon
 pub enum DaemonCommand {
-    SetFanSpeed { ac: usize, rpm: i32 },      // Fan speed
-    GetFanSpeed { ac: usize },                 // Get (Fan speed)
-    SetPowerMode { ac: usize, pwr: u8, cpu: u8, gpu: u8}, // Power mode
-    GetPwrLevel { ac: usize },                 // Get (Power mode)
-    GetCPUBoost { ac: usize },                 // Get (CPU boost)
-    GetGPUBoost { ac: usize },                 // Get (GPU boost)
-    SetLogoLedState{ ac:usize, logo_state: u8 },
-    GetLogoLedState { ac: usize },
-    GetKeyboardRGB { layer: i32 }, // Layer ID
-    SetEffect { name: String, params: Vec<u8> }, // Set keyboard colour
-    SetStandardEffect { name: String, params: Vec<u8> }, // Set keyboard colour
-    SetBrightness { ac:usize, val: u8 },
-    SetIdle {ac: usize, val: u32 },
-    GetBrightness { ac: usize },
-    SetSync { sync: bool },
-    GetSync (),
-    SetBatteryHealthOptimizer { is_on: bool, threshold: u8 },
-    GetBatteryHealthOptimizer (),
-    GetDeviceName 
+    SetFanSpeed {
+        ac: usize,
+        rpm: i32,
+    }, // Fan speed
+    GetFanSpeed {
+        ac: usize,
+    }, // Get (Fan speed)
+    SetPowerMode {
+        ac: usize,
+        pwr: u8,
+        cpu: u8,
+        gpu: u8,
+    }, // Power mode
+    GetPwrLevel {
+        ac: usize,
+    }, // Get (Power mode)
+    GetCPUBoost {
+        ac: usize,
+    }, // Get (CPU boost)
+    GetGPUBoost {
+        ac: usize,
+    }, // Get (GPU boost)
+    SetLogoLedState {
+        ac: usize,
+        logo_state: u8,
+    },
+    GetLogoLedState {
+        ac: usize,
+    },
+    GetKeyboardRGB {
+        layer: i32,
+    }, // Layer ID
+    SetEffect {
+        name: String,
+        params: Vec<u8>,
+    }, // Set keyboard colour
+    SetStandardEffect {
+        name: String,
+        params: Vec<u8>,
+    }, // Set keyboard colour
+    SetBrightness {
+        ac: usize,
+        val: u8,
+    },
+    SetIdle {
+        ac: usize,
+        val: u32,
+    },
+    GetBrightness {
+        ac: usize,
+    },
+    SetSync {
+        sync: bool,
+    },
+    GetSync(),
+    SetBatteryHealthOptimizer {
+        is_on: bool,
+        threshold: u8,
+    },
+    GetBatteryHealthOptimizer(),
+    GetDeviceName,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 /// Represents data sent back from Daemon after it receives
 /// a command.
 pub enum DaemonResponse {
-    SetFanSpeed { result: bool },                    // Response
-    GetFanSpeed { rpm: i32 },                        // Get (Fan speed)
-    SetPowerMode { result: bool },                   // Response
-    GetPwrLevel { pwr: u8 },                         // Get (Power mode)
-    GetCPUBoost { cpu: u8 },                         // Get (CPU boost)
-    GetGPUBoost { gpu: u8 },                         // Get (GPU boost)
-    SetLogoLedState {result: bool },
+    SetFanSpeed { result: bool },  // Response
+    GetFanSpeed { rpm: i32 },      // Get (Fan speed)
+    SetPowerMode { result: bool }, // Response
+    GetPwrLevel { pwr: u8 },       // Get (Power mode)
+    GetCPUBoost { cpu: u8 },       // Get (CPU boost)
+    GetGPUBoost { gpu: u8 },       // Get (GPU boost)
+    SetLogoLedState { result: bool },
     GetLogoLedState { logo_state: u8 },
     GetKeyboardRGB { layer: i32, rgbdata: Vec<u8> }, // Response (RGB) of 90 keys
-    SetEffect { result: bool },                       // Set keyboard colour
-    SetStandardEffect { result: bool },                       // Set keyboard colour
+    SetEffect { result: bool },                      // Set keyboard colour
+    SetStandardEffect { result: bool },              // Set keyboard colour
     SetBrightness { result: bool },
     SetIdle { result: bool },
     GetBrightness { result: u8 },
@@ -51,16 +94,12 @@ pub enum DaemonResponse {
     GetSync { sync: bool },
     SetBatteryHealthOptimizer { result: bool },
     GetBatteryHealthOptimizer { is_on: bool, threshold: u8 },
-    GetDeviceName { name: String }
+    GetDeviceName { name: String },
 }
 
 #[allow(dead_code)]
 pub fn bind() -> Option<UnixStream> {
-    if let Ok(socket) = UnixStream::connect(SOCKET_PATH) {
-        return Some(socket);
-    } else {
-        return None;
-    }
+    UnixStream::connect(SOCKET_PATH).ok()
 }
 
 #[allow(dead_code)]
@@ -71,43 +110,48 @@ pub fn try_bind() -> std::io::Result<UnixStream> {
 
 #[allow(dead_code)]
 pub fn create() -> Option<UnixListener> {
-    if let Ok(_) = std::fs::metadata(SOCKET_PATH) {
+    if std::fs::metadata(SOCKET_PATH).is_ok() {
         eprintln!("UNIX Socket already exists. Is another daemon running?");
         return None;
     }
-    if let Ok(listener) = UnixListener::bind(SOCKET_PATH) {
+    UnixListener::bind(SOCKET_PATH).ok().and_then(|listener| {
         let mut perms = std::fs::metadata(SOCKET_PATH).unwrap().permissions();
-        perms.set_readonly(false);
-        if std::fs::set_permissions(SOCKET_PATH, perms).is_err() {
-            eprintln!("Could not set socket permissions");
-            return None;
-        }
-        return Some(listener);
-    }
-    return None;
+        // TODO(phush0): previously, set_readonly makes the permission a+w. I'm assuming this
+        // is intentional. Unsure what you think the permission bits should be.
+        perms.set_mode(0o777);
+
+        std::fs::set_permissions(SOCKET_PATH, perms)
+            .inspect_err(|_| {
+                eprintln!("Could not set socket permissions");
+            })
+            .is_ok()
+            .then_some(listener)
+    })
 }
 
 #[allow(dead_code)]
 pub fn send_to_daemon(command: DaemonCommand, mut sock: UnixStream) -> Option<DaemonResponse> {
-    if let Ok(encoded) = bincode::serialize(&command) {
-        if sock.write_all(&encoded).is_ok() {
-            let mut buf = [0u8; 4096];
-            return match sock.read(&mut buf) {
-                Ok(readed) if readed > 0 => read_from_socked_resp(&buf[0..readed]),
-                Ok(_) => {
-                    eprintln!("No response from daemon");
-                    None
+    bincode::serialize(&command).ok().and_then(|encoded| {
+        sock.write_all(&encoded)
+            .inspect_err(|_| {
+                eprintln!("Socket write failed!");
+            })
+            .ok()
+            .and_then(|_| {
+                let mut buf = [0u8; 4096];
+                match sock.read(&mut buf) {
+                    Ok(readed) if readed > 0 => read_from_socked_resp(&buf[0..readed]),
+                    Ok(_) => {
+                        eprintln!("No response from daemon");
+                        None
+                    }
+                    Err(_) => {
+                        eprintln!("Read failed!");
+                        None
+                    }
                 }
-                Err(_) => {
-                    eprintln!("Read failed!");
-                    None
-                }
-            };
-        } else {
-            eprintln!("Socket write failed!");
-        }
-    }
-    return None;
+            })
+    })
 }
 
 /// Deserializes incomming bytes in order to return
@@ -116,11 +160,11 @@ fn read_from_socked_resp(bytes: &[u8]) -> Option<DaemonResponse> {
     match bincode::deserialize::<DaemonResponse>(bytes) {
         Ok(res) => {
             println!("RES: {:?}", res);
-            return Some(res);
+            Some(res)
         }
         Err(e) => {
             println!("RES ERROR: {}", e);
-            return None;
+            None
         }
     }
 }
@@ -132,11 +176,11 @@ pub fn read_from_socket_req(bytes: &[u8]) -> Option<DaemonCommand> {
     match bincode::deserialize::<DaemonCommand>(bytes) {
         Ok(res) => {
             println!("REQ: {:?}", res);
-            return Some(res);
+            Some(res)
         }
         Err(e) => {
             println!("REQ ERROR: {}", e);
-            return None;
+            None
         }
     }
 }

--- a/razer_control_gui/src/razer-settings/razer-settings.rs
+++ b/razer_control_gui/src/razer-settings/razer-settings.rs
@@ -1,26 +1,26 @@
 use std::io::ErrorKind;
 
 use gtk::prelude::*;
+use gtk::{glib, glib::clone};
 use gtk::{Application, ApplicationWindow};
 use gtk::{
-    Box, Label, Scale, Stack, StackSwitcher, Switch, ToolItem, Toolbar,
-    ComboBoxText, Button, ColorButton, LinkButton
+    Box, Button, ColorButton, ComboBoxText, Label, LinkButton, Scale, Stack, StackSwitcher, Switch,
+    ToolItem, Toolbar,
 };
-use gtk::{glib, glib::clone};
-        
+
 // sudo apt install libgdk-pixbuf2.0-dev libcairo-dev libatk1.0-dev
 // sudo apt install libpango1.0-dev
 
 #[path = "../comms.rs"]
 mod comms;
 mod error_handling;
-mod widgets;
 mod util;
+mod widgets;
 
-use service::SupportedDevice;
 use error_handling::*;
-use widgets::*;
+use service::SupportedDevice;
 use util::*;
+use widgets::*;
 
 fn send_data(opt: comms::DaemonCommand) -> Option<comms::DaemonResponse> {
     match comms::try_bind() {
@@ -40,9 +40,7 @@ fn get_device_name() -> Option<String> {
 
     use comms::DaemonResponse::*;
     match response {
-        GetDeviceName { name } => {
-            Some(name)
-        }
+        GetDeviceName { name } => Some(name),
         response => {
             // This should not happen
             println!("Instead of GetDeviceName got {response:?}");
@@ -56,9 +54,7 @@ fn get_bho() -> Option<(bool, u8)> {
 
     use comms::DaemonResponse::*;
     match response {
-        GetBatteryHealthOptimizer { is_on, threshold } => {
-            Some((is_on, threshold))
-        }
+        GetBatteryHealthOptimizer { is_on, threshold } => Some((is_on, threshold)),
         response => {
             // This should not happen
             println!("Instead of GetBatteryHealthOptimizer got {response:?}");
@@ -68,15 +64,11 @@ fn get_bho() -> Option<(bool, u8)> {
 }
 
 fn set_bho(is_on: bool, threshold: u8) -> Option<bool> {
-    let response = send_data(comms::DaemonCommand::SetBatteryHealthOptimizer {
-        is_on, threshold
-    })?;
+    let response = send_data(comms::DaemonCommand::SetBatteryHealthOptimizer { is_on, threshold })?;
 
     use comms::DaemonResponse::*;
     match response {
-        SetBatteryHealthOptimizer { result } => {
-            Some(result)
-        }
+        SetBatteryHealthOptimizer { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetBatteryHealthOptimizer got {response:?}");
@@ -87,13 +79,11 @@ fn set_bho(is_on: bool, threshold: u8) -> Option<bool> {
 
 fn get_brightness(ac: bool) -> Option<u8> {
     let ac = if ac { 1 } else { 0 };
-    let response = send_data(comms::DaemonCommand::GetBrightness{ ac })?;
+    let response = send_data(comms::DaemonCommand::GetBrightness { ac })?;
 
     use comms::DaemonResponse::*;
     match response {
-        GetBrightness { result } => {
-            Some(result)
-        }
+        GetBrightness { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of GetBrightness got {response:?}");
@@ -108,9 +98,7 @@ fn set_brightness(ac: bool, val: u8) -> Option<bool> {
 
     use comms::DaemonResponse::*;
     match response {
-        SetBrightness { result } => {
-            Some(result)
-        }
+        SetBrightness { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetBrightness got {response:?}");
@@ -121,13 +109,11 @@ fn set_brightness(ac: bool, val: u8) -> Option<bool> {
 
 fn get_logo(ac: bool) -> Option<u8> {
     let ac = if ac { 1 } else { 0 };
-    let response = send_data(comms::DaemonCommand::GetLogoLedState{ ac })?;
+    let response = send_data(comms::DaemonCommand::GetLogoLedState { ac })?;
 
     use comms::DaemonResponse::*;
     match response {
-        GetLogoLedState { logo_state } => {
-            Some(logo_state)
-        }
+        GetLogoLedState { logo_state } => Some(logo_state),
         response => {
             // This should not happen
             println!("Instead of GetLogoLedState got {response:?}");
@@ -138,13 +124,11 @@ fn get_logo(ac: bool) -> Option<u8> {
 
 fn set_logo(ac: bool, logo_state: u8) -> Option<bool> {
     let ac = if ac { 1 } else { 0 };
-    let response = send_data(comms::DaemonCommand::SetLogoLedState{ ac , logo_state })?;
+    let response = send_data(comms::DaemonCommand::SetLogoLedState { ac, logo_state })?;
 
     use comms::DaemonResponse::*;
     match response {
-        SetLogoLedState { result } => {
-            Some(result)
-        }
+        SetLogoLedState { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetLogoLedState got {response:?}");
@@ -155,14 +139,13 @@ fn set_logo(ac: bool, logo_state: u8) -> Option<bool> {
 
 fn set_effect(name: &str, values: Vec<u8>) -> Option<bool> {
     let response = send_data(comms::DaemonCommand::SetEffect {
-        name: name.into(), params: values
+        name: name.into(),
+        params: values,
     })?;
 
     use comms::DaemonResponse::*;
     match response {
-        SetEffect { result } => {
-            Some(result)
-        }
+        SetEffect { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetEffect got {response:?}");
@@ -172,11 +155,11 @@ fn set_effect(name: &str, values: Vec<u8>) -> Option<bool> {
 }
 
 fn get_power(ac: bool) -> Option<(u8, u8, u8)> {
+    use comms::DaemonResponse::*;
     let ac = if ac { 1 } else { 0 };
     let mut result = (0, 0, 0);
 
-    let response = send_data(comms::DaemonCommand::GetPwrLevel{ ac })?;
-    use comms::DaemonResponse::*;
+    let response = send_data(comms::DaemonCommand::GetPwrLevel { ac })?;
     match response {
         GetPwrLevel { pwr } => {
             result.0 = pwr;
@@ -184,12 +167,11 @@ fn get_power(ac: bool) -> Option<(u8, u8, u8)> {
         response => {
             // This should not happen
             println!("Instead of GetPwrLevel got {response:?}");
-            return None
+            return None;
         }
     }
 
     let response = send_data(comms::DaemonCommand::GetCPUBoost { ac })?;
-    use comms::DaemonResponse::*;
     match response {
         GetCPUBoost { cpu } => {
             result.1 = cpu;
@@ -197,12 +179,11 @@ fn get_power(ac: bool) -> Option<(u8, u8, u8)> {
         response => {
             // This should not happen
             println!("Instead of GetCPUBoost got {response:?}");
-            return None
+            return None;
         }
     }
 
     let response = send_data(comms::DaemonCommand::GetGPUBoost { ac })?;
-    use comms::DaemonResponse::*;
     match response {
         GetGPUBoost { gpu } => {
             result.2 = gpu;
@@ -210,7 +191,7 @@ fn get_power(ac: bool) -> Option<(u8, u8, u8)> {
         response => {
             // This should not happen
             println!("Instead of GetGPUBoost got {response:?}");
-            return None
+            return None;
         }
     }
 
@@ -220,14 +201,15 @@ fn get_power(ac: bool) -> Option<(u8, u8, u8)> {
 fn set_power(ac: bool, power: (u8, u8, u8)) -> Option<bool> {
     let ac = if ac { 1 } else { 0 };
     let response = send_data(comms::DaemonCommand::SetPowerMode {
-        ac, pwr: power.0, cpu: power.1, gpu: power.2 }
-    )?;
+        ac,
+        pwr: power.0,
+        cpu: power.1,
+        gpu: power.2,
+    })?;
 
     use comms::DaemonResponse::*;
     match response {
-        SetPowerMode { result } => {
-            Some(result)
-        }
+        SetPowerMode { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetPowerMode got {response:?}");
@@ -238,13 +220,11 @@ fn set_power(ac: bool, power: (u8, u8, u8)) -> Option<bool> {
 
 fn get_fan_speed(ac: bool) -> Option<i32> {
     let ac = if ac { 1 } else { 0 };
-    let response = send_data(comms::DaemonCommand::GetFanSpeed{ ac })?;
+    let response = send_data(comms::DaemonCommand::GetFanSpeed { ac })?;
 
     use comms::DaemonResponse::*;
     match response {
-        GetFanSpeed { rpm } => {
-            Some(rpm)
-        }
+        GetFanSpeed { rpm } => Some(rpm),
         response => {
             // This should not happen
             println!("Instead of GetFanSpeed got {response:?}");
@@ -255,13 +235,11 @@ fn get_fan_speed(ac: bool) -> Option<i32> {
 
 fn set_fan_speed(ac: bool, value: i32) -> Option<bool> {
     let ac = if ac { 1 } else { 0 };
-    let response = send_data(comms::DaemonCommand::SetFanSpeed{ ac, rpm: value })?;
+    let response = send_data(comms::DaemonCommand::SetFanSpeed { ac, rpm: value })?;
 
     use comms::DaemonResponse::*;
     match response {
-        SetFanSpeed { result } => {
-            Some(result)
-        }
+        SetFanSpeed { result } => Some(result),
         response => {
             // This should not happen
             println!("Instead of SetFanSpeed got {response:?}");
@@ -274,13 +252,12 @@ fn main() {
     setup_panic_hook();
     gtk::init().or_crash("Failed to initialize GTK.");
 
-    let device_file = std::fs::read_to_string(service::DEVICE_FILE)
-        .or_crash("Failed to read the device file");
-    let devices: Vec<SupportedDevice> = serde_json::from_str(&device_file)
-        .or_crash("Failed to parse the device file");
+    let device_file =
+        std::fs::read_to_string(service::DEVICE_FILE).or_crash("Failed to read the device file");
+    let devices: Vec<SupportedDevice> =
+        serde_json::from_str(&device_file).or_crash("Failed to parse the device file");
 
-    let device_name = get_device_name()
-        .or_crash("Failed to get device name");
+    let device_name = get_device_name().or_crash("Failed to get device name");
 
     let app = Application::builder()
         .application_id("com.example.hello") // TODO: Change this name
@@ -290,7 +267,9 @@ fn main() {
         // For now we get the device from the device name. One is duplicated but
         // its settings are the same.
         // TODO: Document this or make it more robust
-        let device = devices.iter().find(|d| d.name == device_name)
+        let device = devices
+            .iter()
+            .find(|d| d.name == device_name)
             .or_crash("Failed to get device info");
 
         let window = ApplicationWindow::builder()
@@ -310,7 +289,11 @@ fn main() {
         stack.set_transition_type(gtk::StackTransitionType::SlideLeftRight);
 
         stack.add_titled(&ac_settings_page.master_container, "AC", "AC");
-        stack.add_titled(&battery_settings_page.master_container, "Battery", "Battery");
+        stack.add_titled(
+            &battery_settings_page.master_container,
+            "Battery",
+            "Battery",
+        );
         stack.add_titled(&general_page.master_container, "General", "General");
         stack.add_titled(&about_page.master_container, "About", "About");
 
@@ -327,7 +310,7 @@ fn main() {
         stack_switcher.connect_screen_changed(|_, _| {
             println!("Page changed");
         });
-        
+
         let vbox = gtk::Box::new(gtk::Orientation::Vertical, 0);
         let toolbar = Toolbar::new();
         toolbar.style_context().add_class("primary-toolbar");
@@ -351,9 +334,8 @@ fn main() {
 
         // If we know we are not running on AC, we show the battery tab by
         // default
-        match check_if_running_on_ac_power() {
-            Some(false) => stack.set_visible_child_name("Battery"),
-            _ => {}
+        if let Some(false) = check_if_running_on_ac_power() {
+            stack.set_visible_child_name("Battery")
         }
     });
 
@@ -365,10 +347,8 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
     let brightness = get_brightness(ac).or_crash("Error reading brightness");
     let power = get_power(ac);
 
-    let min_fan_speed = *device.fan.get(0)
-        .or_crash("Invalid fan values") as f64;
-    let max_fan_speed = *device.fan.get(1)
-        .or_crash("Invalid fan values") as f64;
+    let min_fan_speed = *device.fan.get(0).or_crash("Invalid fan values") as f64;
+    let max_fan_speed = *device.fan.get(1).or_crash("Invalid fan values") as f64;
 
     let settings_page = SettingsPage::new();
 
@@ -376,18 +356,18 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
     if device.has_logo() {
         let logo = get_logo(ac).or_crash("Error reading logo");
         let settings_section = settings_page.add_section(Some("Logo"));
-            let label = Label::new(Some("Turn on logo"));
-            let logo_options = ComboBoxText::new();
-                logo_options.append_text("Off");
-                logo_options.append_text("On");
-                logo_options.append_text("Breathing");
-                logo_options.set_active(Some(logo as u32));
-            logo_options.connect_changed(move |options| {
-                let logo = options.active().or_crash("Illegal state") as u8;
-                set_logo(ac, logo);
-                let logo = get_logo(ac).or_crash("Error reading logo").clamp(0, 2);
-                options.set_active(Some(logo as u32));
-            });
+        let label = Label::new(Some("Turn on logo"));
+        let logo_options = ComboBoxText::new();
+        logo_options.append_text("Off");
+        logo_options.append_text("On");
+        logo_options.append_text("Breathing");
+        logo_options.set_active(Some(logo as u32));
+        logo_options.connect_changed(move |options| {
+            let logo = options.active().or_crash("Illegal state") as u8;
+            set_logo(ac, logo);
+            let logo = get_logo(ac).or_crash("Error reading logo").clamp(0, 2);
+            options.set_active(Some(logo as u32));
+        });
         let row = SettingsRow::new(&label, &logo_options);
         settings_section.add_row(&row.master_container);
     }
@@ -395,35 +375,37 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
     // Power section
     if let Some(power) = power {
         let settings_section = settings_page.add_section(Some("Power"));
-            let label = Label::new(Some("Power Profile"));
-            let power_profile = ComboBoxText::new();
-                power_profile.append_text("Balanced");
-                power_profile.append_text("Gaming");
-                power_profile.append_text("Creator");
-                power_profile.append_text("Silent");
-                power_profile.append_text("Custom");
-                power_profile.set_active(Some(power.0 as u32));
-                power_profile.set_width_request(100);
+        let label = Label::new(Some("Power Profile"));
+        let power_profile = ComboBoxText::new();
+        power_profile.append_text("Balanced");
+        power_profile.append_text("Gaming");
+        power_profile.append_text("Creator");
+        power_profile.append_text("Silent");
+        power_profile.append_text("Custom");
+        power_profile.set_active(Some(power.0 as u32));
+        power_profile.set_width_request(100);
         let row = SettingsRow::new(&label, &power_profile);
         settings_section.add_row(&row.master_container);
-            let label = Label::new(Some("CPU Boost"));
-            let cpu_boost = ComboBoxText::new();
-                cpu_boost.append_text("Low");
-                cpu_boost.append_text("Medium");
-                cpu_boost.append_text("High");
-                if device.can_boost() { cpu_boost.append_text("Boost") };
-                cpu_boost.set_active(Some(power.1 as u32));
-                cpu_boost.set_width_request(100);
+        let label = Label::new(Some("CPU Boost"));
+        let cpu_boost = ComboBoxText::new();
+        cpu_boost.append_text("Low");
+        cpu_boost.append_text("Medium");
+        cpu_boost.append_text("High");
+        if device.can_boost() {
+            cpu_boost.append_text("Boost")
+        };
+        cpu_boost.set_active(Some(power.1 as u32));
+        cpu_boost.set_width_request(100);
         let row = SettingsRow::new(&label, &cpu_boost);
         let cpu_boost_row = &row.master_container;
         settings_section.add_row(cpu_boost_row);
-            let label = Label::new(Some("GPU Boost"));
-            let gpu_boost = ComboBoxText::new();
-                gpu_boost.append_text("Low");
-                gpu_boost.append_text("Medium");
-                gpu_boost.append_text("High");
-                gpu_boost.set_active(Some(power.2 as u32));
-                gpu_boost.set_width_request(100);
+        let label = Label::new(Some("GPU Boost"));
+        let gpu_boost = ComboBoxText::new();
+        gpu_boost.append_text("Low");
+        gpu_boost.append_text("Medium");
+        gpu_boost.append_text("High");
+        gpu_boost.set_active(Some(power.2 as u32));
+        gpu_boost.set_width_request(100);
         let row = SettingsRow::new(&label, &gpu_boost);
         let gpu_boost_row = &row.master_container;
         settings_section.add_row(gpu_boost_row);
@@ -498,18 +480,23 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
 
     // Fan Speed Section
     let settings_section = settings_page.add_section(Some("Fan Speed"));
-        let label = Label::new(Some("Auto"));
-        let switch = Switch::new();
-        let auto = fan_speed == 0;
-        switch.set_state(auto);
+    let label = Label::new(Some("Auto"));
+    let switch = Switch::new();
+    let auto = fan_speed == 0;
+    switch.set_state(auto);
     let row = SettingsRow::new(&label, &switch);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Fan Speed"));
-        let scale = Scale::with_range(gtk::Orientation::Horizontal, min_fan_speed, max_fan_speed, 1f64);
-        scale.set_value(fan_speed as f64);
-        scale.set_sensitive(fan_speed != 0);
-        scale.set_width_request(100);
-        scale.connect_change_value(clone!(@weak switch => @default-return gtk::glib::Propagation::Stop, move |scale, stype, value| {
+    let label = Label::new(Some("Fan Speed"));
+    let scale = Scale::with_range(
+        gtk::Orientation::Horizontal,
+        min_fan_speed,
+        max_fan_speed,
+        1f64,
+    );
+    scale.set_value(fan_speed as f64);
+    scale.set_sensitive(fan_speed != 0);
+    scale.set_width_request(100);
+    scale.connect_change_value(clone!(@weak switch => @default-return gtk::glib::Propagation::Stop, move |scale, _stype, value| {
             let value = value.clamp(min_fan_speed, max_fan_speed);
             set_fan_speed(ac, value as i32).or_crash("Error setting fan speed");
             let fan_speed = get_fan_speed(ac).or_crash("Error reading fan speed");
@@ -519,7 +506,7 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
             switch.set_state(auto);
             return gtk::glib::Propagation::Stop;
         }));
-        switch.connect_changed_active(clone!(@weak scale => move |switch| {
+    switch.connect_changed_active(clone!(@weak scale => move |switch| {
             set_fan_speed(ac, if switch.is_active() { 0 } else { min_fan_speed as i32 }).or_crash("Error setting fan speed");
             let fan_speed = get_fan_speed(ac).or_crash("Error reading fan speed");
             let auto = fan_speed == 0;
@@ -532,17 +519,17 @@ fn make_page(ac: bool, device: SupportedDevice) -> SettingsPage {
 
     // Keyboard Section
     let settings_section = settings_page.add_section(Some("Keyboard"));
-        let label = Label::new(Some("Brightness"));
-        let scale = Scale::with_range(gtk::Orientation::Horizontal, 0f64, 100f64, 1f64);
+    let label = Label::new(Some("Brightness"));
+    let scale = Scale::with_range(gtk::Orientation::Horizontal, 0f64, 100f64, 1f64);
+    scale.set_value(brightness as f64);
+    scale.set_width_request(100);
+    scale.connect_change_value(move |scale, _stype, value| {
+        let value = value.clamp(0f64, 100f64);
+        set_brightness(ac, value as u8).or_crash("Error setting brightness");
+        let brightness = get_brightness(ac).or_crash("Error reading brightness");
         scale.set_value(brightness as f64);
-        scale.set_width_request(100);
-        scale.connect_change_value(move |scale, stype, value| {
-            let value = value.clamp(0f64, 100f64);
-            set_brightness(ac, value as u8).or_crash("Error setting brigthness");
-            let brightness = get_brightness(ac).or_crash("Error reading brightness");
-            scale.set_value(brightness as f64);
-            return gtk::glib::Propagation::Stop;
-        });
+        gtk::glib::Propagation::Stop
+    });
     let row = SettingsRow::new(&label, &scale);
     settings_section.add_row(&row.master_container);
 
@@ -556,26 +543,27 @@ fn make_general_page() -> SettingsPage {
 
     // Keyboard Section
     let settings_section = page.add_section(Some("Keyboard"));
-        let label = Label::new(Some("Effect"));
-        let effect_options = ComboBoxText::new();
-            effect_options.append_text("Static");
-            effect_options.append_text("Static Gradient");
-            effect_options.append_text("Wave Gradient");
-            effect_options.append_text("Breathing");
-            effect_options.set_active(Some(0));
+    let label = Label::new(Some("Effect"));
+    let effect_options = ComboBoxText::new();
+    effect_options.append_text("Static");
+    effect_options.append_text("Static Gradient");
+    effect_options.append_text("Wave Gradient");
+    effect_options.append_text("Breathing");
+    effect_options.set_active(Some(0));
     let row = SettingsRow::new(&label, &effect_options);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Color 1"));
-        let color_picker = ColorButton::new();
+    let label = Label::new(Some("Color 1"));
+    let color_picker = ColorButton::new();
     let row = SettingsRow::new(&label, &color_picker);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Color 2"));
-        let color_picker_2 = ColorButton::new();
+    let label = Label::new(Some("Color 2"));
+    let color_picker_2 = ColorButton::new();
     let row = SettingsRow::new(&label, &color_picker_2);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Write effect"));
-        let button = Button::with_label("Write");
-        button.connect_clicked(clone!(@weak effect_options, @weak color_picker, @weak color_picker_2 =>
+    let label = Label::new(Some("Write effect"));
+    let button = Button::with_label("Write");
+    button.connect_clicked(
+        clone!(@weak effect_options, @weak color_picker, @weak color_picker_2 =>
             move |_| {
                 let color = color_picker.color();
                 let red   = (color.red   / 256) as u8;
@@ -613,15 +601,15 @@ fn make_general_page() -> SettingsPage {
                     _ => {}
                 }
             }
-        ));
+        ),
+    );
     let row = SettingsRow::new(&label, &button);
     settings_section.add_row(&row.master_container);
-
 
     effect_options.connect_changed(clone!(@weak color_picker, @weak color_picker_2 =>
         move |options| {
             let logo = options.active().or_crash("Illegal state"); // Unwrap: There is always one active
-            
+
             match logo {
                 0 => {
                     // TODO: Color 1 visible
@@ -643,43 +631,43 @@ fn make_general_page() -> SettingsPage {
     // Battery Health Optimizer section
     if let Some(bho) = bho {
         let settings_section = page.add_section(Some("Battery Health Optimizer"));
-            let label = Label::new(Some("Enable Battery Health Optimizer"));
-            let switch = Switch::new();
-            switch.set_state(bho.0);
+        let label = Label::new(Some("Enable Battery Health Optimizer"));
+        let switch = Switch::new();
+        switch.set_state(bho.0);
         let row = SettingsRow::new(&label, &switch);
         settings_section.add_row(&row.master_container);
-            let label = Label::new(Some("Theshold"));
-            let scale = Scale::with_range(gtk::Orientation::Horizontal, 65f64, 80f64, 1f64);
-            scale.set_value(bho.1 as f64);
-            scale.set_width_request(100);
-            scale.connect_change_value(clone!(@weak switch => @default-return gtk::glib::Propagation::Stop, move |scale, stype, value| {
+        let label = Label::new(Some("Theshold"));
+        let scale = Scale::with_range(gtk::Orientation::Horizontal, 65f64, 80f64, 1f64);
+        scale.set_value(bho.1 as f64);
+        scale.set_width_request(100);
+        scale.connect_change_value(clone!(@weak switch => @default-return gtk::glib::Propagation::Stop, move |scale, _stype, value| {
                 let is_on = switch.is_active();
                 let threshold = value.clamp(50f64, 80f64) as u8;
 
                 set_bho(is_on, threshold).or_crash("Error setting bho");
 
                 let (is_on, threshold) = get_bho().or_crash("Error reading bho");
-                
+
                 scale.set_value(threshold as f64);
                 scale.set_visible(is_on);
                 scale.set_sensitive(is_on);
 
                 return gtk::glib::Propagation::Stop;
             }));
-            scale.set_sensitive(bho.0);
-            switch.connect_changed_active(clone!(@weak scale => move |switch| {
-                let is_on = switch.is_active();
-                let threshold = scale.value().clamp(50f64, 80f64) as u8;
-                
-                set_bho(is_on, threshold); // Ignoramos errores ya que leemos
-                                           // el resultado de vuelta
+        scale.set_sensitive(bho.0);
+        switch.connect_changed_active(clone!(@weak scale => move |switch| {
+            let is_on = switch.is_active();
+            let threshold = scale.value().clamp(50f64, 80f64) as u8;
 
-                let (is_on, threshold) = get_bho().or_crash("Error reading bho");
-                
-                scale.set_value(threshold as f64);
-                scale.set_visible(is_on);
-                scale.set_sensitive(is_on);
-            }));
+            set_bho(is_on, threshold); // Ignoramos errores ya que leemos
+                                       // el resultado de vuelta
+
+            let (is_on, threshold) = get_bho().or_crash("Error reading bho");
+
+            scale.set_value(threshold as f64);
+            scale.set_visible(is_on);
+            scale.set_sensitive(is_on);
+        }));
         let row = SettingsRow::new(&label, &scale);
         settings_section.add_row(&row.master_container);
     }
@@ -692,29 +680,32 @@ fn make_about_page(device: SupportedDevice) -> SettingsPage {
 
     // About page
     let settings_section = page.add_section(Some("Razer Laptop Control"));
-        let label = Label::new(Some("Project"));
-        let url = LinkButton::with_label("https://github.com/JosuGZ/razer-laptop-control", "Project repository");
+    let label = Label::new(Some("Project"));
+    let url = LinkButton::with_label(
+        "https://github.com/JosuGZ/razer-laptop-control",
+        "Project repository",
+    );
     let row = SettingsRow::new(&label, &url);
     settings_section.add_row(&row.master_container);
-        let report_bug_url = "https://github.com/JosuGZ/razer-laptop-control/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D";
-        let label = Label::new(Some("Bug reports"));
-        let url = LinkButton::with_label(report_bug_url, "Report bug");
+    let report_bug_url = "https://github.com/JosuGZ/razer-laptop-control/issues/new?labels=bug&template=bug_report.md&title=%5BBUG%5D";
+    let label = Label::new(Some("Bug reports"));
+    let url = LinkButton::with_label(report_bug_url, "Report bug");
     let row = SettingsRow::new(&label, &url);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Discord"));
-        let url = LinkButton::with_label("https://discord.gg/GdHKf45", "Razer Linux");
+    let label = Label::new(Some("Discord"));
+    let url = LinkButton::with_label("https://discord.gg/GdHKf45", "Razer Linux");
     let row = SettingsRow::new(&label, &url);
     settings_section.add_row(&row.master_container);
 
     // Model section
     let settings_section = page.add_section(Some("Laptop Information"));
-        let label = Label::new(Some("Model"));
-        let model_label = Label::new(Some(&device.name));
+    let label = Label::new(Some("Model"));
+    let model_label = Label::new(Some(&device.name));
     let row = SettingsRow::new(&label, &model_label);
     settings_section.add_row(&row.master_container);
-        let label = Label::new(Some("Features"));
-        let features = device.features.join(", ");
-        let features_label = Label::new(Some(&features));
+    let label = Label::new(Some("Features"));
+    let features = device.features.join(", ");
+    let features_label = Label::new(Some(&features));
     let row = SettingsRow::new(&label, &features_label);
     settings_section.add_row(&row.master_container);
 

--- a/razer_control_gui/src/razer-settings/widgets.rs
+++ b/razer_control_gui/src/razer-settings/widgets.rs
@@ -1,17 +1,14 @@
 use std::cell::Cell;
 
 use gtk::prelude::*;
-use gtk::{
-    Box, Frame, Label, ListBox, ListBoxRow, Separator, Widget, Grid
-};
+use gtk::{Box, Frame, Grid, Label, ListBox, ListBoxRow, Separator, Widget};
 
 pub struct SettingsPage {
     // TODO: Can I make this a widget? This is self originally
-    pub master_container: Box
+    pub master_container: Box,
 }
 
 impl SettingsPage {
-    
     pub fn new() -> SettingsPage {
         let master_container = Box::new(gtk::Orientation::Vertical, 15);
         master_container.set_margin_start(80);
@@ -19,26 +16,23 @@ impl SettingsPage {
         master_container.set_margin_top(15);
         master_container.set_margin_bottom(15);
 
-        SettingsPage {
-            master_container
-        }
+        SettingsPage { master_container }
     }
 
     pub fn add_section(&self, title: Option<&str>) -> SettingsSection {
         let section = SettingsSection::new(title);
-        self.master_container.pack_start(&section.master_container, false, false, 0);
+        self.master_container
+            .pack_start(&section.master_container, false, false, 0);
         section
     }
-
 }
 
 pub struct SettingsRow {
     // TODO: Can I make this a widget? This is self originally
-    pub master_container: ListBoxRow
+    pub master_container: ListBoxRow,
 }
 
 impl SettingsRow {
-    
     pub fn new(
         label: &impl IsA<Widget>,
         main_widget: &impl IsA<Widget>,
@@ -66,23 +60,27 @@ impl SettingsRow {
         description_box.add(label);
 
         grid.attach(&description_box, 0, 0, 1, 1);
-        grid.attach_next_to(main_widget /*stack*/, Some(&description_box), gtk::PositionType::Right, 1, 1);
+        grid.attach_next_to(
+            main_widget, /*stack*/
+            Some(&description_box),
+            gtk::PositionType::Right,
+            1,
+            1,
+        );
         hbox.add(&grid); // TODO: No es así como lo hacen
-        
+
         master_container.add(&hbox);
 
-        SettingsRow {
-            master_container
-        }
+        SettingsRow { master_container }
     }
 
+    #[allow(dead_code)]
     pub fn add_section(&self, title: Option<&str>) -> SettingsSection {
         let section = SettingsSection::new(title);
         // self.master_container.pack_start(&section.master_container, false, false, 0); TODO: It should be this
         self.master_container.add(&section.master_container);
         section
     }
-
 }
 
 pub struct SettingsSection {
@@ -90,11 +88,10 @@ pub struct SettingsSection {
     pub master_container: Box,
     container: Box,
     frame: Frame,
-    need_separator: Cell<bool>
+    need_separator: Cell<bool>,
 }
 
 impl SettingsSection {
-
     pub fn new(title: Option<&str>) -> SettingsSection {
         let master_container = Box::new(gtk::Orientation::Vertical, 10);
 
@@ -123,7 +120,7 @@ impl SettingsSection {
             master_container,
             container,
             frame,
-            need_separator: Cell::new(false)
+            need_separator: Cell::new(false),
         }
     }
 


### PR DESCRIPTION
Hello!

Thanks for making this awesome crate. It works well!

If you're accepting PRs, I'd be happy to contribute. I was wondering if you would be interested in some help cleaning up some of the lints found in this crate. 

I was halfway through the daemon module, but realized that a lot of the code is auto-generated. I was thinking updating of either 
1. updating `dbus-codegen-rust` to fix the lints + redundant traits
2. creating a macro to implement `OrgFreedesktop*`, `OrgKde*`, for the associated modules
I'll need to look into what's going on here, or a suggestion on what you're looking for would be awesome! Particularly, I'm wondering if these files are ever regenerated from this codegen.

Additionally, a lot of the lints deal with the `return` keyword. I realize this is solely a stylistic preference that Rust doesn't want its developers to use, so let me know if that lint should be disabled. I don't use it at least, but it's no issue that it is.


Used some declarative paradigm code in comms. This may not be to the maintainer's liking. May want to revert some of this.

Thanks for your advice!